### PR TITLE
check if source info is null before adding it to the sorted source list

### DIFF
--- a/src/components/Results/index.tsx
+++ b/src/components/Results/index.tsx
@@ -149,7 +149,10 @@ const getSortedList = (sourceList: any[]) => {
   // Re-order the list based on the preset source list (this fixes the order of the tabs)
   SOURCE_IDS.forEach((sourceId: string) => {
     const entry = sourceMap[sourceId]
-    orderedList.push(entry)
+
+    if(entry != null){
+      orderedList.push(entry);
+    }
   })
 
   return orderedList


### PR DESCRIPTION
SOURCE_IDS is a hardcoded object containing info for enrichment, pathway figures, interactome, etc.  They are ordered based on the results from the server.  Since the server for cBio portal is only returning enrichment results, these hardcoded objects return null when sorted.  

To fix this issue, perform a null check before pushing the ordered item.

refs #UD-2018